### PR TITLE
MoveFocusAbs Patch

### DIFF
--- a/patches/movefocusabs.patch
+++ b/patches/movefocusabs.patch
@@ -1,0 +1,52 @@
+diff --git a/sara.c b/sara.c
+index f8295ef..11086d5 100644
+--- a/sara.c
++++ b/sara.c
+@@ -204,6 +204,7 @@ static void manipulate(const Arg arg);
+ static void moveclient(const Arg arg);
+ static void moveclientup(client* c, int wantzoom);
+ static void movefocus(const Arg arg);
++static void movefocusabs(const Arg arg);
+ static void resizeclient(client* c, int x, int y, int w, int h);
+ static void restack(monitor* m);
+ static void sendmon(client* c, monitor* m);
+@@ -260,6 +261,7 @@ struct {
+ 	{killclient,    "killclient"},
+ 	{moveclient,    "moveclient"},
+ 	{movefocus,     "movefocus"},
++	{movefocusabs,  "movefocusabs"},
+ 	{quit,          "quit"},
+ 	{todesktop,     "todesktop"},
+ 	{toggledesktop, "toggledesktop"},
+@@ -760,6 +762,31 @@ movefocus(const Arg arg){
+ 	}
+ }
+ 
++void
++movefocusabs(const Arg arg){
++	client* j, * c = NULL;
++	int i = 0;
++	if (!curmon->current || curmon->current->isfull)
++		return;
++
++	parser[WantInt](arg.s, &parg);
++
++	if (parg.i >= 0){
++		for EACHCLIENT(curmon->head){
++			if (ISVISIBLE(ic) && ic->desks == 1 << curmon->curdesk){
++				if (i==parg.i)
++					c = ic;
++				i++;
++			}
++		}
++	}
++
++	if (c && c != curmon->current){
++		changecurrent(c, curmon, curmon->curdesk, 0);
++		restack(curmon);
++	}
++}
++
+ void
+ manipulate(const Arg arg){
+ 	int x, y, ocx, ocy, nx, ny, nw, nh;


### PR DESCRIPTION
And another patch. This one adds a function to focus a window directly: for example `sarasock 'movefocusabs 0'` focuses the master window, `sarasock 'movefocusabs 2'` the third window on the current desktop.
I will just send you all my changes as patches so you can decide if you want to incorporate them into the base or keep them as patches.